### PR TITLE
Updated default Node version to v18

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To start adapting this configuration for your own image, you can customize some 
 
 * `do_api_token` defines the DO API Token used to create resources via DigitalOcean's API. By default it is set to the value of the `DIGITALOCEAN_API_TOKEN` environment variable.
 * `image_name` defines the name of the resulting snapshot, which by default is `ghost-snapshot-` with a UNIX timestamp appended.
-* `node_version` defines the apt repo to use to install Node JS (eg. `node_14.x`, `node_16.x` etc)
+* `node_version` defines the apt repo to use to install Node JS (eg. `node_16.x`, `node_18.x` etc)
 
 You can also modify these variables at runtime by using [the `-var` flag](https://www.packer.io/docs/templates/user-variables.html#setting-variables).
 

--- a/ghost-image.json
+++ b/ghost-image.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "ghost-1click-{{timestamp}}",
-    "node_version": "node_16.x",
+    "node_version": "node_18.x",
     "apt_packages": "cloud-image-utils git jq libguestfs-tools make mysql-server make nginx postfix python3-certbot super unzip"
   },
   "sensitive-variables": ["do_api_token"],

--- a/scripts/014-configure_ghost.sh
+++ b/scripts/014-configure_ghost.sh
@@ -15,6 +15,7 @@ cat > /etc/sudoers.d/99-do-ghost <<EOM
 ghost-mgr ALL=(ALL) NOPASSWD:ALL
 EOM
 
+chmod 755 /var/www
 mkdir -p /var/www/ghost
 chown -R ghost-mgr: /var/www/ghost
 chmod 775 /var/www/ghost


### PR DESCRIPTION
refs https://github.com/TryGhost/DevOps/issues/7

- this bumps the default Node version to v18
- updates default MySQL host from localhost to 127.0.0.1 because Node 18 defaults to looking up via IPv6 and we're only listening on IPv4