### PR TITLE
Updated to Node 22 / Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To start adapting this configuration for your own image, you can customize some 
 
 * `do_api_token` defines the DO API Token used to create resources via DigitalOcean's API. By default it is set to the value of the `DIGITALOCEAN_API_TOKEN` environment variable.
 * `image_name` defines the name of the resulting snapshot, which by default is `ghost-snapshot-` with a UNIX timestamp appended.
-* `node_version` defines the apt repo to use to install Node JS (eg. `node_16.x`, `node_18.x` etc)
+* `node_version` defines the apt repo to use to install Node JS (eg. `20`, `22` etc)
 
 You can also modify these variables at runtime by using [the `-var` flag](https://www.packer.io/docs/templates/user-variables.html#setting-variables).
 

--- a/ghost-image.json
+++ b/ghost-image.json
@@ -3,7 +3,7 @@
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "ghost-1click-{{timestamp}}",
     "node_version": "22",
-    "apt_packages": "cloud-image-utils git jq libguestfs-tools make mysql-server make nginx postfix python3-certbot super unzip"
+    "apt_packages": "ca-certificates cloud-image-utils curl git gnupg jq libguestfs-tools make mysql-server make nginx postfix python3-certbot super unzip"
   },
   "sensitive-variables": ["do_api_token"],
   "builders": [

--- a/ghost-image.json
+++ b/ghost-image.json
@@ -2,7 +2,7 @@
   "variables": {
     "do_api_token": "{{env `DIGITALOCEAN_API_TOKEN`}}",
     "image_name": "ghost-1click-{{timestamp}}",
-    "node_version": "node_18.x",
+    "node_version": "22",
     "apt_packages": "cloud-image-utils git jq libguestfs-tools make mysql-server make nginx postfix python3-certbot super unzip"
   },
   "sensitive-variables": ["do_api_token"],
@@ -10,7 +10,7 @@
     {
       "type": "digitalocean",
       "api_token": "{{user `do_api_token`}}",
-      "image": "ubuntu-22-04-x64",
+      "image": "ubuntu-24-04-x64",
       "region": "ams3",
       "size": "s-1vcpu-1gb",
       "ssh_username": "root",

--- a/scripts/010-nodejs.sh
+++ b/scripts/010-nodejs.sh
@@ -3,13 +3,15 @@
 ##
 ## vi: syntax=sh expandtab ts=4
 
-curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
-
 # Replace with the branch of Node.js or io.js you want to install: node_6.x, node_8.x, etc...
 VERSION=${NODE_VERSION}
 
-# Add Node.js repository
-curl -fsSL https://deb.nodesource.com/setup_$VERSION.x | bash -
+# Create a directory for the new repository's keyring, if it doesn't exist
+mkdir -p /etc/apt/keyrings
+# Download the new repository's GPG key and save it in the keyring directory
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+# Add the new repository's source list with its GPG key for package verification
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${VERSION}.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
 # Yarn
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -

--- a/scripts/010-nodejs.sh
+++ b/scripts/010-nodejs.sh
@@ -7,13 +7,9 @@ curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key ad
 
 # Replace with the branch of Node.js or io.js you want to install: node_6.x, node_8.x, etc...
 VERSION=${NODE_VERSION}
-# The below command will set this correctly, but if lsb_release isn't available, you can set it manually:
-# - For Debian distributions: jessie, sid, etc...
-# - For Ubuntu distributions: xenial, bionic, etc...
-# - For Debian or Ubuntu derived distributions your best option is to use the codename corresponding to the upstream release your distribution is based off. This is an advanced scenario and unsupported if your distribution is not listed as supported per earlier in this README.
-DISTRO="$(lsb_release -s -c)"
-echo "deb https://deb.nodesource.com/$VERSION $DISTRO main" | sudo tee /etc/apt/sources.list.d/nodesource.list
-echo "deb-src https://deb.nodesource.com/$VERSION $DISTRO main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list
+
+# Add Node.js repository
+curl -fsSL https://deb.nodesource.com/setup_$VERSION.x | bash -
 
 # Yarn
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -

--- a/scripts/020-application_tag.sh
+++ b/scripts/020-application_tag.sh
@@ -10,8 +10,8 @@ cat >> /var/lib/digitalocean/application.info <<EOM
 appiication_name="Ghost"
 build_date="${build_date}
 distro=Ubuntu
-distro_release=20.04
-distro_codename=focal
+distro_release=24.04
+distro_codename=noble
 distro_arch=amd64
 application_version="${version}"
 EOM


### PR DESCRIPTION
Tidied up the allowed operating systems and switched to the recommended method for installing Node

It doesn't seem like it would be possible to install this with CentOS / other rpm-based distributions, so I've removed the support for them and the `if` blocks for them. We have `apt` commands in the Node setup which have existed for years that would break on those. While doing this, I've also updated the versions of Ubuntu / Debian which are allowed, since older versions can't install Node 22.

The bigger change here is switching to using the scripted version to install the NodeSource repository. This feels fine to me, since they're already a dependency. The reason for this change though, was that the version of nodejs being installed was not correctly pinning to the NodeSource version in Ubuntu 24.04 when we used the old method to simply add the key. 