### PR TITLE
Added command for installing digitalocean packer plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ packer build ghost-image.json
 
 ### Usage
 
-To run the Packer build that this template uses by default, you'll need to [install Packer](https://www.packer.io/intro/getting-started/install.html) and [create a DigitalOcean personal access token](https://www.digitalocean.com/docs/api/create-personal-access-token/) and set it to the `DIGITALOCEAN_API_TOKEN` environment variable. Running `packer build ghost-image.json` without any other modifications will create a build Droplet configured with Ghost, clean and verify it, then power it down and snapshot it.
+To run the Packer build that this template uses by default, you'll need to [install Packer](https://www.packer.io/intro/getting-started/install.html), the digitalocean packer plugin (`packer plugins install github.com/digitalocean/digitalocean`) and [create a DigitalOcean personal access token](https://www.digitalocean.com/docs/api/create-personal-access-token/) and set it to the `DIGITALOCEAN_API_TOKEN` environment variable. Running `packer build ghost-image.json` without any other modifications will create a build Droplet configured with Ghost, clean and verify it, then power it down and snapshot it.
 
 > ⚠️ The image validation script in `scripts/999-img_check.sh` is copied from the [top-level `scripts` directory](../scripts) in this repository. The top-level location is the script's canonical source, so make sure you're using the latest version from there.
 


### PR DESCRIPTION
no issue

- since packer v1.7 individual builders are shipped as separate packages and need to be installed before builds will succeed
