### PR TITLE
Increased memory requirement from 1GB to 2GB

### DIFF
--- a/ghost-image.json
+++ b/ghost-image.json
@@ -12,7 +12,7 @@
       "api_token": "{{user `do_api_token`}}",
       "image": "ubuntu-24-04-x64",
       "region": "ams3",
-      "size": "s-1vcpu-1gb",
+      "size": "s-1vcpu-2gb",
       "ssh_username": "root",
       "snapshot_name": "{{user `image_name`}}"
     }


### PR DESCRIPTION
According to DO's instructions in Slack, increasing the RAM of the builder droplet will increase the minimum size of the droplet when restoring from the snapshot (i.e. when creating the DO image from the 1-click UI).